### PR TITLE
Adding evolution to the world tick

### DIFF
--- a/app/models/creature.rb
+++ b/app/models/creature.rb
@@ -3,18 +3,47 @@ class Creature < ApplicationRecord
     ALIVE_STATUS="alive",
     DEAD_STATUS="dead",
   ].map(&:freeze).freeze
-  
+
   validates :hunger, numericality: { only_integer: true, in: 0..10 }
   validates :status, inclusion: { in: ALLOWED_STATUSES }
-  
+
+  belongs_to :current_evolution, class_name: "Evolution"
+
   def tick
+    # hunger
     increment!(:hunger)
     if hunger == 10
       die!
     end
+
+    # evolve
+    evolution_threshold = evolution_comparison_timestamp + 
+      current_evolution.life_span_in_minutes.minutes
+    
+    if Time.now > evolution_threshold
+      evolve_or_die!
+    end
+  end
+
+  def evolve_or_die!
+    return die! if current_evolution.children.none?
+    evolve!
+  end
+
+  private
+
+  def evolve!
+    update!(
+      current_evolution: current_evolution.children.sample,
+      last_evolved_at: Time.now
+    )
   end
 
   def die!
     update!(status: DEAD_STATUS)
+  end
+
+  def evolution_comparison_timestamp
+    last_evolved_at || created_at
   end
 end

--- a/app/models/evolution.rb
+++ b/app/models/evolution.rb
@@ -15,4 +15,8 @@ class Evolution < ApplicationRecord
     through: :child_transitions, 
     class_name: "Evolution",
     source: :child_evolution
+
+  has_many :creatures, foreign_key: :current_evolution_id
+
+  scope :babies, -> { where.missing(:parents) }
 end

--- a/app/operations/creatures/create.rb
+++ b/app/operations/creatures/create.rb
@@ -1,15 +1,23 @@
 module Creatures
   class Create < Dry::Operation
     def call()
-      creature = step create_creature
+      initial_evolution = step choose_initial_evolution
+      creature = step create_creature(initial_evolution: initial_evolution)
       serialized_creature = step serialize_creature(creature)
       serialized_creature
     end
-    
-    def create_creature
-      Success(Creature.create!(uuid: SecureRandom.uuid))
+
+    def choose_initial_evolution
+      Success(Evolution.babies.sample)
     end
-    
+
+    def create_creature(initial_evolution:)
+      Success(Creature.create!(
+        uuid: SecureRandom.uuid,
+        current_evolution: initial_evolution
+      ))
+    end
+
     def serialize_creature(creature)
       Success({uuid: creature.uuid})
     end

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,6 +16,8 @@ services:
       - 4000:4000
     tty: true
     stdin_open: true
+    depends_on:
+      - db
   db:
     image: postgres:17
     restart: always

--- a/config/database.yml
+++ b/config/database.yml
@@ -61,6 +61,10 @@ development:
 test:
   <<: *default
   database: tamagotchi_test
+  username: postgres
+  password: foobarbaz
+  host: db
+  timeout: 5000
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/db/migrate/20241115133805_add_creature_current_evolution.rb
+++ b/db/migrate/20241115133805_add_creature_current_evolution.rb
@@ -1,0 +1,5 @@
+class AddCreatureCurrentEvolution < ActiveRecord::Migration[8.0]
+  def change
+    add_column :creatures, :current_evolution_id, :bigint, null: false
+  end
+end

--- a/db/migrate/20241115140956_add_time_to_evolve_to_evolutions.rb
+++ b/db/migrate/20241115140956_add_time_to_evolve_to_evolutions.rb
@@ -1,0 +1,5 @@
+class AddTimeToEvolveToEvolutions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :evolutions, :life_span_in_minutes, :int, null: false, default: 60
+  end
+end

--- a/db/migrate/20241115141107_add_last_evolved_at_to_creatures.rb
+++ b/db/migrate/20241115141107_add_last_evolved_at_to_creatures.rb
@@ -1,0 +1,5 @@
+class AddLastEvolvedAtToCreatures < ActiveRecord::Migration[8.0]
+  def change
+    add_column :creatures, :last_evolved_at, :datetime, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_11_15_124919) do
+ActiveRecord::Schema[8.0].define(version: 2024_11_15_141107) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -20,6 +20,8 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_15_124919) do
     t.integer "hunger", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "current_evolution_id", null: false
+    t.datetime "last_evolved_at"
   end
 
   create_table "evolution_transitions", force: :cascade do |t|
@@ -35,5 +37,6 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_15_124919) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "life_span_in_minutes", default: 60, null: false
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,6 +11,7 @@
 # Temporary destroy_all
 Evolution.destroy_all
 EvolutionTransition.destroy_all
+Creature.destroy_all
 
 piglet = Evolution.create!(name: "Piglet")
 pig = Evolution.create!(name: "Pig")
@@ -23,7 +24,12 @@ piglet.children << [pig, boar]
 pig.children << [mecha_pig, fat_boy]
 boar.children << [fat_boy, roid_boar]
 
-# piglet -> pi`g ->` mecha pig
+pig_creature = Creature.create!(
+  current_evolution: pig,
+  uuid: SecureRandom.uuid
+)
+
+# piglet -> pig -> mecha pig
 #               -> fatboy
 #           boar -> fatboy
 #                -> roidboar

--- a/spec/end_to_end/creature_birth_to_death_spec.rb
+++ b/spec/end_to_end/creature_birth_to_death_spec.rb
@@ -8,4 +8,26 @@ describe "The world deamon ticking a creature to death" do
 
     expect(creature.reload.status).to eq(Creature::DEAD_STATUS)
   end
+
+  it "evolves a creature every hour, and kills it when it is fully evolved" do
+    piglet = create(:evolution, name: "Piglet", life_span_in_minutes: 60)
+    pig = create(:evolution, name: "Pig", life_span_in_minutes: 60)
+    mecha_pig = create(:evolution, name: "Mecha Pig", life_span_in_minutes: 60)
+    piglet.children << pig
+    pig.children << mecha_pig
+    creature = create(:creature, current_evolution: piglet)
+    daemon = WorldDaemon.new(sleep_time: 0)
+
+    travel_to 1.hour.from_now + 1.minute
+    daemon.tick_world
+    expect(creature.reload.current_evolution).to eq(pig)
+
+    travel_to 2.hours.from_now + 1.minute
+    daemon.tick_world
+    expect(creature.reload.current_evolution).to eq(mecha_pig)
+
+    travel_to 3.hours.from_now + 1.minute
+    daemon.tick_world
+    expect(creature.reload.status).to eq(Creature::DEAD_STATUS)
+  end
 end

--- a/spec/factories/creatures.rb
+++ b/spec/factories/creatures.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :creature do
     uuid { SecureRandom.uuid }
+    association :current_evolution, factory: "evolution"
   end
 end

--- a/spec/factories/evolutions.rb
+++ b/spec/factories/evolutions.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :evolution do
+    name { "test-evolution" }
+
+    trait :baby do
+      # No parent evolutions
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,4 +67,6 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include FactoryBot::Syntax::Methods
+  config.include ActiveSupport::Testing::TimeHelpers
+
 end

--- a/spec/requests/api/v1/creatures_spec.rb
+++ b/spec/requests/api/v1/creatures_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 describe "Creatures resource" do
   describe "POST /api/v1/creatures" do
     it "creates a new creature and responds with a serialized version" do
+      create(:evolution, :baby, name: "Piglet")
       expect { post api_v1_creatures_path }
       .to change { Creature.count }
       .by(1)


### PR DESCRIPTION
Implementing a birth to death end to end spec, a creature now goes through all of its available evolutions going up the tree randomising which evolution to choose

Later stages we need to add how the creature will evolve and change up the defaults of how quickly it moves through the different lifestyle cycles - these have been set as very basic to begin with so we can test the functionality